### PR TITLE
Add FreeBSD resolver support

### DIFF
--- a/network/defaults.yaml
+++ b/network/defaults.yaml
@@ -129,4 +129,8 @@ RedHat:
         ip: ff02::2
       - name: ip6-allhosts
         ip: ff02::3
+FreeBSD:
+  resolver:
+    values:
+      path: /etc/resolv.conf
 {% endload %}


### PR DESCRIPTION
Fixes an undefined variable error when using `network.resolver`. I haven't added any other defaults as I'm only using this portion of the formula for now; I'd be happy to add them once I'm using and able to test them.
