### PR TITLE
Remove root group reference

### DIFF
--- a/network/resolver.sls
+++ b/network/resolver.sls
@@ -9,7 +9,6 @@ resolver:
     - name: {{ datamap.resolver.path|default('/etc/resolv.conf') }}
     - mode: 644
     - user: root
-    - group: root
     - contents: |
 {%- if salt['pillar.get']('network:resolver:file_prepend', False) %}
         {{ salt['pillar.get']('network:resolver:file_prepend') }}


### PR DESCRIPTION
It causes errors where there is no root group (such as FreeBSD, where
group 0 is wheel).
