### PR TITLE
Add the posibility to skip interface reconfig.

### DIFF
--- a/network/defaults.yaml
+++ b/network/defaults.yaml
@@ -31,6 +31,8 @@ Debian:
       - ipv6ipaddr
       - ipv6netmask
       - ipv6gateway
+
+      - noifupdown
     def_entries:
       - name: lo
         proto: loopback
@@ -92,6 +94,8 @@ RedHat:
       - ipv6ipaddr
       - ipv6netmask
       - ipv6gateway
+
+      - noifupdown
     def_entries: []
 #      - name: lo
 #        proto: none


### PR DESCRIPTION
This patch requires my salstatck/salt pull
request [#25165](https://github.com/saltstack/salt/pull/25165).