### PR TITLE
routes: pass gateway param only if defined

### DIFF
--- a/network/routes.sls
+++ b/network/routes.sls
@@ -16,6 +16,8 @@ routes_{{ v.name|default(k) }}:
       - name: {{ net.name }}
         ipaddr: {{ net.ipaddr }}
         netmask: {{ net.netmask }}
+        {% if net.gateway is defined %}
         gateway: {{ net.gateway }}
+        {% endif %}
   {% endfor %}
 {% endfor %}


### PR DESCRIPTION
routes: pass gateway param only if defined , it fix interface routes without defined gateway